### PR TITLE
Corrects assumed typo from RFC_3614 to RFC_3164

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ messageSender.setDefaultFacility(Facility.USER);
 messageSender.setDefaultSeverity(Severity.INFORMATIONAL);
 messageSender.setSyslogServerHostname("127.0.0.1");
 messageSender.setSyslogServerPort(1234);
-messageSender.setMessageFormat(MessageFormat.RFC_3614); // optional, default is RFC 3164
+messageSender.setMessageFormat(MessageFormat.RFC_3164); // optional, default is RFC 3164
 messageSender.setSsl(false);
 
 // send a Syslog message
@@ -79,7 +79,7 @@ messageSender.setDefaultFacility(Facility.USER);
 messageSender.setDefaultSeverity(Severity.INFORMATIONAL);
 messageSender.setSyslogServerHostname("127.0.0.1");
 messageSender.setSyslogServerPort(1234);
-messageSender.setMessageFormat(MessageFormat.RFC_3614); // optional, default is RFC 3164
+messageSender.setMessageFormat(MessageFormat.RFC_3164); // optional, default is RFC 3164
 messageSender.setSsl(true);
 
 // send a Syslog message


### PR DESCRIPTION
Typo was in sample TCP Java code in README.md a couple of times.