### PR TITLE
Make it configurable to end messages with CR LF for TCPSender

### DIFF
--- a/src/main/java/com/cloudbees/syslog/sender/TcpSyslogMessageSender.java
+++ b/src/main/java/com/cloudbees/syslog/sender/TcpSyslogMessageSender.java
@@ -76,6 +76,9 @@ public class TcpSyslogMessageSender extends AbstractSyslogMessageSender {
      */
     protected final AtomicInteger trySendErrorCounter = new AtomicInteger();
 
+    // use the CR LF non transparent framing as described in "3.4.2.  Non-Transparent-Framing"
+    private String postfix = "\r\n";
+
     @Override
     public synchronized void sendMessage(@Nonnull SyslogMessage message) throws IOException {
         sendCounter.incrementAndGet();
@@ -90,8 +93,7 @@ public class TcpSyslogMessageSender extends AbstractSyslogMessageSender {
                     }
                     ensureSyslogServerConnection();
                     message.toSyslogMessage(messageFormat, writer);
-                    // use the CR LF non transparent framing as described in "3.4.2.  Non-Transparent-Framing"
-                    writer.write("\r\n");
+                    writer.write(postfix);
                     writer.flush();
                     return;
                 } catch (IOException e) {
@@ -238,6 +240,10 @@ public class TcpSyslogMessageSender extends AbstractSyslogMessageSender {
 
     public void setMaxRetryCount(int maxRetryCount) {
         this.maxRetryCount = maxRetryCount;
+    }
+
+    public void setPostfix(String postfix) {
+        this.postfix = postfix;
     }
 
     @Override


### PR DESCRIPTION
My syslog messages ends with "^M"  like this one: 
```
 Mar 14 14:05:36 envy-172-17-136-2.devops someDaemon: INFO [2017-03-14T14:05:35.950Z] [EventDispatcherCollection] Worker added^M
```

It would be nice to make it optional to include the \r\n , this PR makes that possible

This PR makes it possible to add any kind of postfix to the messages. 