### PR TITLE
Corrected header for RFC 5424 Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Client library written in Java to send messages to a Syslog server.
 
 // Initialise sender
 UdpSyslogMessageSender messageSender = new UdpSyslogMessageSender();
-messageSender.setDefaultMessageHostName("myhostname"); // some syslog cloud services may use this field to transmit a secret key
+messageSender.setDefaultMessageHostname("myhostname"); // some syslog cloud services may use this field to transmit a secret key
 messageSender.setDefaultAppName("myapp");
 messageSender.setDefaultFacility(Facility.USER);
 messageSender.setDefaultSeverity(Severity.INFORMATIONAL);
@@ -36,7 +36,7 @@ messageSender.sendMessage("This is a test message");
 
 // Initialise sender
 SyslogMessageUdpSender messageSender = new SyslogMessageUdpSender();
-messageSender.setDefaultMessageHostName("myhostname"); // some syslog cloud services may use this field to transmit a secret key
+messageSender.setDefaultMessageHostname("myhostname"); // some syslog cloud services may use this field to transmit a secret key
 messageSender.setDefaultAppName("myapp");
 messageSender.setDefaultFacility(Facility.USER);
 messageSender.setDefaultSeverity(Severity.INFORMATIONAL);
@@ -54,7 +54,7 @@ messageSender.sendMessage("This is a test message");
 
 // Initialise sender
 TcpSyslogMessageSender messageSender = new TcpSyslogMessageSender();
-messageSender.setDefaultMessageHostName("myhostname"); // some syslog cloud services may use this field to transmit a secret key
+messageSender.setDefaultMessageHostname("myhostname"); // some syslog cloud services may use this field to transmit a secret key
 messageSender.setDefaultAppName("myapp");
 messageSender.setDefaultFacility(Facility.USER);
 messageSender.setDefaultSeverity(Severity.INFORMATIONAL);
@@ -73,7 +73,7 @@ messageSender.sendMessage("This is a test message");
 
 // Initialise sender
 TcpSyslogMessageSender messageSender = new TcpSyslogMessageSender();
-messageSender.setDefaultMessageHostName("myhostname"); // some syslog cloud services may use this field to transmit a secret key
+messageSender.setDefaultMessageHostname("myhostname"); // some syslog cloud services may use this field to transmit a secret key
 messageSender.setDefaultAppName("myapp");
 messageSender.setDefaultFacility(Facility.USER);
 messageSender.setDefaultSeverity(Severity.INFORMATIONAL);


### PR DESCRIPTION
Corrected header for RFC 5424 Example and Corrected typo in documentation for method setDefaultMessageHostname