### PR TITLE
The list of reserved SD-ID's was incorrect.  Changed to the correct list

### DIFF
--- a/src/main/java/com/cloudbees/syslog/SDElement.java
+++ b/src/main/java/com/cloudbees/syslog/SDElement.java
@@ -35,9 +35,8 @@ public class SDElement implements Serializable {
      */
     public static final String[] RESERVED_SDID = new String[]{
         "timeQuality",
-        "tzKnown",
-        "isSynced",
-        "syncAccuracy"
+        "origin",
+        "meta"
     };
 
     public SDElement(String sdID) {


### PR DESCRIPTION
I read the spec wrong for the set of reserved SD-ID's.  I have corrected this list to be the 3 that are in the spec:

timeQuality (section 7.1)
origin (section 7.2)
meta (section 7.3)
