### PR TITLE
RFC 5425 message format

### DIFF
--- a/src/main/java/com/cloudbees/syslog/MessageFormat.java
+++ b/src/main/java/com/cloudbees/syslog/MessageFormat.java
@@ -28,5 +28,9 @@ public enum MessageFormat {
     /**
      * <a href="https://tools.ietf.org/html/rfc5424">RFC 5424 - The Syslog Protocol</a>
      */
-    RFC_5424
+    RFC_5424,
+    /**
+     * <a href="https://tools.ietf.org/html/rfc5425">RFC 5425 - Transport Layer Security (TLS) Transport Mapping for Syslog</a>
+     */
+    RFC_5425
 }

--- a/src/main/java/com/cloudbees/syslog/SyslogMessage.java
+++ b/src/main/java/com/cloudbees/syslog/SyslogMessage.java
@@ -17,12 +17,15 @@ package com.cloudbees.syslog;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+
+import java.io.ByteArrayOutputStream;
 import java.io.CharArrayWriter;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Locale;
@@ -249,6 +252,8 @@ public class SyslogMessage {
                 return toRfc3164SyslogMessage();
             case RFC_5424:
                 return toRfc5424SyslogMessage();
+            case RFC_5425:
+                return toRfc5425SyslogMessage();
             default:
                 throw new IllegalStateException("Unsupported message format '" + messageFormat + "'");
         }
@@ -269,9 +274,40 @@ public class SyslogMessage {
             case RFC_5424:
                 toRfc5424SyslogMessage(out);
                 break;
+            case RFC_5425:
+                toRfc5425SyslogMessage(out);
+                break;
             default:
                 throw new IllegalStateException("Unsupported message format '" + messageFormat + "'");
         }
+    }
+
+    /**
+     * Generates an <a href="http://tools.ietf.org/html/rfc5424">RFC-5425</a> message.
+     */
+    public String toRfc5425SyslogMessage() {
+
+        StringWriter sw = new StringWriter(msg == null ? 32 : msg.size() + 32);
+        try {
+            toRfc5425SyslogMessage(sw);
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+        return sw.toString();
+    }
+
+    /**
+     * Generates an <a href="http://tools.ietf.org/html/rfc5425">RFC-5425</a> message.
+     */
+    public void toRfc5425SyslogMessage(Writer out) throws IOException {
+
+        StringWriter sw = new StringWriter(msg == null ? 32 : msg.size() + 32);
+        toRfc5424SyslogMessage(sw);
+        String rfc5424Message = sw.toString();
+        int length = rfc5424Message.getBytes(StandardCharsets.UTF_8).length;
+        out.write(String.valueOf(length));
+        out.write(SP);
+        out.write(rfc5424Message);
     }
 
     /**

--- a/src/main/java/com/cloudbees/syslog/SyslogMessage.java
+++ b/src/main/java/com/cloudbees/syslog/SyslogMessage.java
@@ -18,7 +18,6 @@ package com.cloudbees.syslog;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import java.io.ByteArrayOutputStream;
 import java.io.CharArrayWriter;
 import java.io.IOException;
 import java.io.StringWriter;
@@ -301,9 +300,7 @@ public class SyslogMessage {
      */
     public void toRfc5425SyslogMessage(Writer out) throws IOException {
 
-        StringWriter sw = new StringWriter(msg == null ? 32 : msg.size() + 32);
-        toRfc5424SyslogMessage(sw);
-        String rfc5424Message = sw.toString();
+        String rfc5424Message = toRfc5424SyslogMessage();
         int length = rfc5424Message.getBytes(StandardCharsets.UTF_8).length;
         out.write(String.valueOf(length));
         out.write(SP);

--- a/src/test/java/com/cloudbees/syslog/SyslogMessageTest.java
+++ b/src/test/java/com/cloudbees/syslog/SyslogMessageTest.java
@@ -29,6 +29,35 @@ import static org.junit.Assert.assertThat;
 public class SyslogMessageTest {
 
     @Test
+    public void testRfc5425Format() throws Exception {
+        // GIVEN
+        Calendar cal = Calendar.getInstance();
+        cal.setTimeZone(TimeZone.getTimeZone("GMT"));
+        cal.set(2013, Calendar.DECEMBER, 5, 10, 30, 5);
+        cal.set(Calendar.MILLISECOND, 0);
+
+        System.out.println(SyslogMessage.rfc3339DateFormat.format(cal.getTime()));
+        System.out.println(cal.getTimeInMillis());
+
+
+        SyslogMessage message = new SyslogMessage()
+            .withTimestamp(cal.getTimeInMillis())
+            .withAppName("my_app")
+            .withHostname("myserver.example.com")
+            .withFacility(Facility.USER)
+            .withSeverity(Severity.INFORMATIONAL)
+            .withTimestamp(cal.getTimeInMillis())
+            .withMsg("a syslog message");
+
+        // WHEN
+        String actual = message.toRfc5425SyslogMessage();
+
+        // THEN
+        String expected = "81 <14>1 2013-12-05T10:30:05.000Z myserver.example.com my_app - - - a syslog message";
+        assertThat(actual, is(expected));
+    }
+
+    @Test
     public void testRfc5424Format() throws Exception {
 
         Calendar cal = Calendar.getInstance();


### PR DESCRIPTION
Add support for RFC 5425 message format https://tools.ietf.org/html/rfc5425: Transport Layer Security (TLS) Transport Mapping for Syslog. It's almost the same as 5424, it just adds the size of message before the message itself (see https://tools.ietf.org/html/rfc5425#section-4.3).

Thanks,

Sylvain