### PR TITLE
Stub out methods for hostname and port in the AbstractSyslogMessageSender class

### DIFF
--- a/src/main/java/com/cloudbees/syslog/sender/AbstractSyslogMessageSender.java
+++ b/src/main/java/com/cloudbees/syslog/sender/AbstractSyslogMessageSender.java
@@ -133,6 +133,23 @@ public abstract class AbstractSyslogMessageSender implements SyslogMessageSender
     public void setDefaultSeverity(Severity defaultSeverity) {
         this.defaultSeverity = defaultSeverity;
     }
+    
+    /**
+     * Set the hostname or IP of the syslog server to which messages will be
+     * sent.
+     * 
+     * @param syslogServerHostname 
+     *     The hostname or IP address of the syslog server.
+     */
+    public abstract void setSyslogServerHostname(final String syslogServerHostname);
+    
+    /**
+     * Set the port number of the syslog server to which messages will be sent.
+     * 
+     * @param syslogServerPort
+     *     The port to which syslog messages will be sent.
+     */
+    public abstract void setSyslogServerPort(int syslogServerPort);
 
     @Override
     public String toString() {

--- a/src/main/java/com/cloudbees/syslog/sender/TcpSyslogMessageSender.java
+++ b/src/main/java/com/cloudbees/syslog/sender/TcpSyslogMessageSender.java
@@ -186,6 +186,7 @@ public class TcpSyslogMessageSender extends AbstractSyslogMessageSender {
         }
     }
 
+    @Override
     public void setSyslogServerHostname(final String syslogServerHostname) {
         this.syslogServerHostnameReference = new CachingReference<InetAddress>(DEFAULT_INET_ADDRESS_TTL_IN_NANOS) {
             @Nullable
@@ -200,6 +201,7 @@ public class TcpSyslogMessageSender extends AbstractSyslogMessageSender {
         };
     }
 
+    @Override
     public void setSyslogServerPort(int syslogServerPort) {
         this.syslogServerPort = syslogServerPort;
     }

--- a/src/main/java/com/cloudbees/syslog/sender/UdpSyslogMessageSender.java
+++ b/src/main/java/com/cloudbees/syslog/sender/UdpSyslogMessageSender.java
@@ -102,6 +102,7 @@ public class UdpSyslogMessageSender extends AbstractSyslogMessageSender {
     }
 
 
+    @Override
     public void setSyslogServerHostname(final String syslogServerHostname) {
         this.syslogServerHostnameReference = new CachingReference<InetAddress>(DEFAULT_INET_ADDRESS_TTL_IN_NANOS) {
             @Nullable
@@ -116,6 +117,7 @@ public class UdpSyslogMessageSender extends AbstractSyslogMessageSender {
         };
     }
 
+    @Override
     public void setSyslogServerPort(int syslogServerPort) {
         this.syslogServerPort = syslogServerPort;
     }


### PR DESCRIPTION
This addresses #28, regarding having the methods for setting hostname port in the top-level `AbstractSyslogMessageSender` class.