### PR TITLE
Added option to not flush stream buffers on every message send

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ messageSender.setDefaultSeverity(Severity.INFORMATIONAL);
 messageSender.setSyslogServerHostname("127.0.0.1");
 messageSender.setSyslogServerPort(1234);
 messageSender.setMessageFormat(MessageFormat.RFC_3164); // optional, default is RFC 3164
+// onSend is the default value, other value is onClose which has higher throughput but
+// risks dataloss if the syslog server address dynamically changes 
+messageSender.setSocketFlush(TcpSyslogMessageSender.SocketFlush.onSend); 
 messageSender.setSsl(false);
 
 // send a Syslog message
@@ -119,6 +122,9 @@ messageSender.setDefaultSeverity(Severity.INFORMATIONAL);
 messageSender.setSyslogServerHostname("127.0.0.1");
 messageSender.setSyslogServerPort(1234);
 messageSender.setMessageFormat(MessageFormat.RFC_3164); // optional, default is RFC 3164
+// onSend is the default value, other value is onClose which has higher throughput but
+// risks dataloss if the syslog server address dynamically changes 
+messageSender.setSocketFlush(TcpSyslogMessageSender.SocketFlush.onSend); 
 messageSender.setSsl(true);
 
 // send a Syslog message
@@ -145,6 +151,9 @@ messageSender.setSyslogServerHostname("127.0.0.1");
 // syslog-tls usually uses port 6514 as per https://tools.ietf.org/html/rfc5425#page-11
 messageSender.setSyslogServerPort(6514);
 messageSender.setMessageFormat(MessageFormat.RFC_5425);
+// onSend is the default value, other value is onClose which has higher throughput but
+// risks dataloss if the syslog server address dynamically changes 
+messageSender.setSocketFlush(TcpSyslogMessageSender.SocketFlush.onSend); 
 messageSender.setSsl(true);
 
 // send a Syslog message

--- a/src/test/java/com/cloudbees/syslog/sender/TcpSyslogMessageSenderLoadTest.java
+++ b/src/test/java/com/cloudbees/syslog/sender/TcpSyslogMessageSenderLoadTest.java
@@ -45,6 +45,7 @@ public class TcpSyslogMessageSenderLoadTest {
         // messageSender.setSyslogServerHostname("127.0.0.1");
         messageSender.setSyslogServerPort(46022);
         messageSender.setSsl(true);
+        messageSender.setSocketFlush(TcpSyslogMessageSender.SocketFlush.onSend);
 
         final AtomicInteger count = new AtomicInteger();
 


### PR DESCRIPTION
Provides feature requested in https://github.com/CloudBees-community/syslog-java-client/issues/49

Adds a property to TcpSyslogMessageSender, "SocketFlush", with getters and setters:
Accepted values:

- SocketFlush.onSend - Default value - continues existing behaviour of flushing at every send, to ensure that all data is passed to the syslog server.
- SocketFlush.onClose -New behaviour to only flush stream buffers on syslog client close.  This is higher performance but risks a small amount dataloss if the syslog server reboots. 
